### PR TITLE
Adding page for tags

### DIFF
--- a/categories.md
+++ b/categories.md
@@ -1,0 +1,6 @@
+---
+layout: archive-taxonomies
+type: categories
+title: Categories
+permalink: /categories/
+---


### PR DESCRIPTION
This will fix the issue when you click on `jekyll` and `updates` on the blog posts. You can also tag posts with keywords and they'll automatically get grouped.